### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+README
+Dockerfile-web
+Dockerfile-mongo
+docker-compose.yml
+.git

--- a/Dockerfile-mongo
+++ b/Dockerfile-mongo
@@ -1,0 +1,3 @@
+FROM mongo:latest
+MAINTAINER jose nazario <jose@monkey.org>
+LABEL version="1.0" description="nosqli-labs Docker image"

--- a/Dockerfile-web
+++ b/Dockerfile-web
@@ -1,0 +1,22 @@
+FROM php:7.0-apache
+MAINTAINER jose nazario <jose@monkey.org>
+LABEL version="1.0" description="nosqli-labs Docker image"
+
+# modifying from https://hub.docker.com/r/spittet/php-mongodb/
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927 && \
+    echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.2 main" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list  && \
+	apt-get -qq update && \
+    apt-get install -y mongodb-org --no-install-recommends && \
+	apt-get install -y libssl-dev unzip && \
+    pecl install mongodb && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \	
+    docker-php-ext-enable mongodb && \
+	apt-get -qy autoremove && \
+	apt-get clean && \
+	mkdir -p /data/db && \
+	/usr/bin/mongod --fork --syslog
+
+COPY . /var/www/html
+RUN sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/user_lookup.php && \
+	sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/populate_db.php

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -1,0 +1,12 @@
+# NoSQLiLab in a Docker 
+
+A set of files to establish Docker containers for your NoSQLiLab are included in the project. With them you can quickly establish a testing range, begin your challenges, and reset them as needed. 
+
+# Installation
+
+1. [Install Docker CE for your platform (Windows, Linux, OSX)](https://docs.docker.com/engine/installation/)
+2. [Install Docker-Compose](https://docs.docker.com/compose/install/)
+3. In the top level directory, run `docker-compose build`. This will build the containers for you according to the Dockerfiles.
+4. Launch the containers, run `docker-compose up`. You now have two containers running, one for the web front end and one for the MongoDB server.
+
+You can now browse http://localhost:8080/ and get to work. Reset the database and start the challenges. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '2.1'
+
+services:
+  web:
+    image: nosqli-labs
+    hostname: nosqliweb
+    build:
+      context: .
+      dockerfile: Dockerfile-web
+    networks:
+      - nosqli-network
+    ports:
+      - "8080:80"
+  mongo:
+    container_name: nosqli-mongodb
+    image: mongo:3.4.1
+    build:
+      context: .
+      dockerfile: Dockerfile-mongo
+    networks:
+      - nosqli-network
+    ports:
+      - "27017:27017"
+
+networks:
+  nosqli-network:
+    driver: bridge


### PR DESCRIPTION
adds an Apache+PHP (w/mongodb driver) container and a MongoDB container, networked together

tested on OSX