### PR TITLE
fix #3 in docker

### DIFF
--- a/Dockerfile-web
+++ b/Dockerfile-web
@@ -19,4 +19,5 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927 && \
 
 COPY . /var/www/html
 RUN sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/user_lookup.php && \
-	sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/populate_db.php
+	sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/populate_db.php && \
+	sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/guess_the_key.php

--- a/guess_the_key.php
+++ b/guess_the_key.php
@@ -44,7 +44,7 @@
 			] );
 
 			try {
-				$mongo_driver = new MongoDB\Driver\Manager;
+				$mongo_driver = new MongoDB\Driver\Manager("mongodb://localhost:27017");
 				$cursor = $mongo_driver->executeCommand( 'sans', $cmd );
 				$response = $cursor->toArray()[0];
 


### PR DESCRIPTION
i did some digging last night and noticed that without any args the MongoDB constructor assumes localhost, which barfs in a Docker env. by being explicit about localhost it should work in Vagrant where both Apache-PHP and Mongo are installed in one box and work in Docker where that's two separate containers. the Dockerfile replaces the location in this one, same as others. 

this fixes issue #3, thanks for noticing and reporting. it WAS an oversight on my part when i added Docker support.