### PR TITLE
Update Dockerfiles to fix #5

### DIFF
--- a/Dockerfile-mongo
+++ b/Dockerfile-mongo
@@ -1,3 +1,3 @@
-FROM mongo:latest
-MAINTAINER jose nazario <jose@monkey.org>
-LABEL version="1.0" description="nosqli-labs Docker image"
+# Last minor version that supported eval
+FROM docker.io/library/mongo:4.0-xenial
+LABEL version="1.0" description="nosqli-labs mongo image" image.authors="jose@monkey.org"

--- a/Dockerfile-web
+++ b/Dockerfile-web
@@ -1,23 +1,24 @@
-FROM php:7.0-apache
-MAINTAINER jose nazario <jose@monkey.org>
-LABEL version="1.0" description="nosqli-labs Docker image"
+FROM docker.io/library/php:7.4-apache
+LABEL version="1.0" description="nosqli-labs apache image" image.authors="jose@monkey.org"
 
-# modifying from https://hub.docker.com/r/spittet/php-mongodb/
-
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927 && \
-    echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.2 main" | tee /etc/apt/sources.list.d/mongodb-org-3.2.list  && \
-	apt-get -qq update && \
-    apt-get install -y mongodb-org --no-install-recommends && \
-	apt-get install -y libssl-dev unzip && \
-    pecl install mongodb && \
-    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \	
-    docker-php-ext-enable mongodb && \
-	apt-get -qy autoremove && \
-	apt-get clean && \
-	mkdir -p /data/db && \
-	/usr/bin/mongod --fork --syslog
+# php driver mongodb-1.5.0 is (probably) last one to support mongodb-4.0
+# php 7.4 is (probably) the last to support that driver
+RUN : \
+    && apt-get update -y \
+    && apt-get install -y \
+	git \
+	libssl-dev \
+	libcurl4-openssl-dev \
+    && apt-get -qq update \
+    && pecl install mongodb-1.5.0 \
+    && docker-php-ext-enable mongodb \
+    && apt-get -qy autoremove \
+    && apt-get clean \
+    && echo "extension=mongodb.so" > /usr/local/etc/php/conf.d/mongodb.ini
 
 COPY . /var/www/html
-RUN sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/user_lookup.php && \
-	sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/populate_db.php && \
-	sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/guess_the_key.php
+
+RUN : \
+	&& sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/user_lookup.php \
+	&& sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/populate_db.php \
+	&& sed -i s/"localhost:27017"/"mongo:27017"/g /var/www/html/guess_the_key.php


### PR DESCRIPTION
This updates the Dockerfiles to the last version of mongo that supported eval, 4.0.
That also dictated php mongo driver 1.5 and thus php < 8.0. Happily, the combination works, and is new enough to support amd64, so it runs on current Macs, too.

It uses the more explicit fullly qualified name for the docker images to reduce ambiguity.

It also removes the (unused?) mongo installation
inside Dockerfile-web.

(Also switched to putting && before commands instead of after them in RUN lines, they're harder to miss there. That meant figuring out a no-op command to use right after RUN; chose : as it's probably the simplest and no-oppiest shell command.)